### PR TITLE
注文確認画面で住所の変更ができるように変更しました

### DIFF
--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -17,4 +17,17 @@ class CheckoutController extends Controller
         'cartItems' => $cartItems,
     ]);
     }
+
+    public function updateAddress(Request $request)
+    {
+        $validated = $request->validate([
+            'address' => 'required|string|max:255',
+        ]);
+
+        $user = auth()->user();
+        $user->address = $validated['address'];
+        $user->save();
+
+        return redirect()->back();
+    }
 }

--- a/resources/views/checkout/index.blade.php
+++ b/resources/views/checkout/index.blade.php
@@ -33,6 +33,24 @@
 <h3>購入者氏名: {{ auth()->user()->name }}</h3>
 <h3>配送先： {{ auth()->user()->address }}</h3>
 
+<button id="changeAddressButton">住所を変更する</button>
+<div id="addressForm" style="display: none;">
+    <form action="/update-address" method="POST">
+        @csrf
+        <label for="address">新しい住所:</label>
+        <input type="text" name="address" id="address" required>
+        <button type="submit">更新</button>
+    </form>
+</div>
+
+<script>
+    document.getElementById('changeAddressButton').addEventListener('click', function() {
+        const form = document.getElementById('addressForm');
+        form.style.display = form.style.display === 'none' ? 'block' : 'none';
+    });
+</script>
+
+
 <div class="button">
     <button type="button" class="btn btn-primary" onclick="confirmPurchase()">購入</button>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,4 +27,6 @@ Route::get('/cart', [CartController::class, 'index'])->name('cart.index');//cart
 Route::delete('/cart/{id}', [CartController::class, 'destroy'])->name('cart.destroy');//delete用
 
 Route::post('/chekout', [CheckoutController::class, 'checkout'])->name('checkout');
+Route::get('/chekout', [CheckoutController::class, 'checkout']);
+Route::post('/update-address', [CheckoutController::class, 'updateAddress'])->name('update.address');
 Route::get('/purchase-confirmation', [PurchaseController::class, 'confirmation'])->name('purchase-confirmation');


### PR DESCRIPTION
注文画面で住所が変更できなかったので、変更フォームをjavascriptで記述しました。ここで記述した住所はUserのaddress項目を更新します。